### PR TITLE
bump up version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libv4l-sys"
 description = "A FFI to libv4l"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
Release `v0.2.0`.

# Improvements
- Add ioctl code for supporting `v4l2_ioctl` #1
- Add `cargo test` job to CI workflow #2
- Add pixel format constants (fourcc) #3
