### PR TITLE
make LIBCLANG_INCLUDE_PATH optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Rust FFI wrapper to libv4l.
 ## Build
 
 ```sh
+cargo build
+```
+
+You can specify the path to the system header directory using `LIBCLANG_INCLUDE_PATH`.
+
+```sh
 LIBCLANG_INCLUDE_PATH=/usr/include/clang/7/include cargo build
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -7,10 +7,10 @@ fn main() {
     let libv4l = pkg_config::probe_library("libv4l2").unwrap();
 
     // Path to directories of C header
-    let include_dirs: Vec<PathBuf> = vec![PathBuf::from(
-        &env::var("LIBCLANG_INCLUDE_PATH")
-            .expect("LIBCLANG_INCLUDE_PATH like: /usr/include/clang/9.0.0/include"),
-    )];
+    let include_dirs: Vec<PathBuf> =
+        env::var("LIBCLANG_INCLUDE_PATH")
+            .map(|path| vec![PathBuf::from(path)])
+            .unwrap_or_default();
 
     let include_args: Vec<_> = include_dirs
         .iter()


### PR DESCRIPTION
`LIBCLANG_INCLUDE_PATH`環境変数がなくても`cargo build`できるようにします

rls-vscodeは依存パッケージの`cargo build`が通らないと残りの全てのコードの on-the-fly エラーチェックが効かなくなります．それを修正します．