### PR TITLE
bump up 0.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libv4l-sys"
 description = "A FFI to libv4l"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
crate のバージョンアップ (`0.2.0` -> `0.2.1`)。

## Changes
- `LIBCLANG_INCLUDE_PATH` をオプショナルに変更(#7)
