### PR TITLE
bump up 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "libv4l-sys"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libv4l-sys"
 description = "A FFI to libv4l"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["takayuki goto <takayuki@idein.jp>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
`0.2.2` へのバージョンアップ。

## Bug fixes
- クロスコンパイル出来ない不具合を修正 (#9)
    - クロスコンパイル用 docker-compose.yml を追加
    - クロスコンパイルするCIジョブを追加