### PR TITLE
WIP: feat: Adds arm64 build target for docker-compose

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [target.arm-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             docker-compose build libv4l-test
             docker-compose run --rm libv4l-test
 
-  cross_build:
+  cross_build_armhf:
     parameters:
       <<: *parameter-rust-version
     executor: default
@@ -86,8 +86,8 @@ workflows:
           requires:
             - build_stable
 
-      - cross_build:
-          name: cross_build_fixed
-      - cross_build:
-          name: cross_build_stable
+      - cross_build_armhf:
+          name: cross_build_armhf_fixed
+      - cross_build_armhf:
+          name: cross_build_armhf_stable
           rust: stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,20 @@ jobs:
             docker-compose build libv4l-build-cross-armhf
             docker-compose run --rm libv4l-build-cross-armhf
 
+  cross_build_arm64:
+    parameters:
+      <<: *parameter-rust-version
+    executor: default
+    steps:
+      - setup_docker_compose
+      - run:
+          name: Cross build w/ rustc ver. << parameters.rust >>
+          environment:
+            RUST_CHANNEL: << parameters.rust >>
+          command: |
+            docker-compose build libv4l-build-cross-arm64
+            docker-compose run --rm libv4l-build-cross-arm64
+
 workflows:
   version: 2
   build_and_test:
@@ -90,4 +104,10 @@ workflows:
           name: cross_build_armhf_fixed
       - cross_build_armhf:
           name: cross_build_armhf_stable
+          rust: stable
+
+      - cross_build_arm64:
+          name: cross_build_arm64_fixed
+      - cross_build_arm64:
+          name: cross_build_arm64_stable
           rust: stable

--- a/README.md
+++ b/README.md
@@ -51,3 +51,16 @@ cargo build
 (container)$ file target/arm-unknown-linux-gnueabihf/debug/liblibv4l_sys.rlib
 target/arm-unknown-linux-gnueabihf/debug/liblibv4l_sys.rlib: current ar archive
 ```
+
+### Into `aarch64-unknown-linux-gnu`
+
+```sh
+(host)$ docker-compose build libv4l-build-cross-arm64
+(host)$ docker-compose run --rm libv4l-build-cross-arm64  # Just check if build succeeds
+
+# Manually invoke build command inside container
+(host)$ docker-compose run --rm libv4l-build-cross-arm64 bash
+(container)$ cargo build --target=aarch64-unknown-linux-gnu
+(container)$ file target/aarch64-unknown-linux-gnu/debug/liblibv4l_sys.rlib
+file target/aarch64-unknown-linux-gnu/debug/liblibv4l_sys.rlib: current ar archive
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,3 +41,17 @@ services:
       cargo build --target=arm-unknown-linux-gnueabihf
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "
+
+  libv4l-build-cross-arm64:
+    container_name: libv4l-build-cross-arm64
+    build:
+      context: .
+      dockerfile: dockerfiles/docker-libv4l-build-cross-arm64/Dockerfile
+      args:
+        - RUST_CHANNEL=${RUST_CHANNEL:-stable}
+    command: |
+      bash -xc "
+      rustc --version
+      cargo build --target=aarch64-unknown-linux-gnu
+      cargo build --target=aarch64-unknown-linux-gnu --examples
+      "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.4'
 
 services:
-  cross-rpi-rust: &cross-rust-env
+  cross-armhf-rust: &cross-armhf-rust-env
     image: rust:1.36.0-buster
-    container_name: cross-rpi-rust
+    container_name: cross-armhf-rust
     environment:
       TARGET_ARCH: 'arm-unknown-linux-gnueabihf'
       LIBCLANG_INCLUDE_PATH: '/usr/include/clang/7/include'
@@ -14,9 +14,9 @@ services:
       - cargo-cache:/tmp/.cargo
     working_dir: /tmp/libv4l_sys
 
-  # build project for RaspberryPi
-  cross-build:
-    << : *cross-rust-env
+  # build project for Debian/armhf architecture (mainly for RaspberryPi series).
+  cross-build-armhf:
+    << : *cross-armhf-rust-env
     command: |
       bash -c "
       dpkg --add-architecture armhf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,19 @@ services:
       - cargo-cache:/tmp/.cargo
     working_dir: /tmp/libv4l_sys
 
+  cross-arm64-rust: &cross-arm64-rust-env
+    image: rust:1.36.0-buster
+    container_name: cross-arm64-rust
+    environment:
+      TARGET_ARCH: 'aarch64-unknown-linux-gnu'
+      LIBCLANG_INCLUDE_PATH: '/usr/include/clang/7/include'
+      PKG_CONFIG_PATH: '/usr/lib/aarch64-linux-gnu/pkgconfig'
+      PKG_CONFIG_ALLOW_CROSS: 1
+    volumes:
+      - .:/tmp/libv4l_sys
+      - cargo-cache:/tmp/.cargo
+    working_dir: /tmp/libv4l_sys
+
   # build project for Debian/armhf architecture (mainly for RaspberryPi series).
   cross-build-armhf:
     << : *cross-armhf-rust-env
@@ -28,6 +41,19 @@ services:
       cargo build --target=$${TARGET_ARCH} --example v4l2grab
       "
 
+  # build project for Debian/arm64 architecture (mainly for Jetson series).
+  cross-build-arm64:
+    << : *cross-arm64-rust-env
+    command: |
+      bash -c "
+      dpkg --add-architecture arm64
+      apt-get update -y
+      apt-get install -y libv4l-dev:arm64 libclang-common-7-dev:arm64 libclang-7-dev:arm64
+      apt-get install -y gcc-aarch64-linux-gnu libclang-7-dev
+      rustup target add $${TARGET_ARCH}
+      cargo build --target=$${TARGET_ARCH}
+      cargo build --target=$${TARGET_ARCH} --example v4l2grab
+      "
 
 volumes:
   cargo-cache:

--- a/dockerfiles/docker-libv4l-build-cross-arm64/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-arm64/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.36.0-buster
+
+ENV LIBCLANG_INCLUDE_PATH '/usr/include/clang/7/include'
+ENV PKG_CONFIG_PATH '/usr/lib/aarch64-linux-gnu/pkgconfig'
+ENV PKG_CONFIG_ALLOW_CROSS 1
+
+ARG RUST_CHANNEL
+RUN test ${RUST_CHANNEL}
+
+WORKDIR /tmp/libv4l_sys
+
+RUN dpkg --add-architecture arm64 \
+    && apt-get update -y \
+    && apt-get install -y libv4l-dev:arm64 libclang-common-7-dev:arm64 libclang-7-dev:arm64 \
+    && apt-get install -y gcc-aarch64-linux-gnu libclang-7-dev
+
+RUN rustup toolchain install ${RUST_CHANNEL} \
+    && rustup target add --toolchain ${RUST_CHANNEL} aarch64-unknown-linux-gnu
+
+COPY . /tmp/libv4l_sys
+
+RUN rustup override set ${RUST_CHANNEL}


### PR DESCRIPTION
## Current status

```bash
docker-compose run --rm cross-build-arm64
```

emits `target/aarch64-unknown-linux-gnu/debug/liblibv4l_sys.rlib` .

## Todo

- [x] arm64 cross-build in CI
    - Wants to eliminate duplicate env settings (like `apt-get`) in `.circleci/config.yml` and `docker-compose.yml`.
- [x] Updates README
- [ ] Checks if `cargo build --target aarch64-unknown-linux-gnu` works w/ a crate depends on `lib4l-sys`.

- [ ] change base branch into master