### PR TITLE
refactor: Use docker-compose.yml w/ CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,23 +45,14 @@ jobs:
   test:
     parameters:
       <<: *parameter-rust-version
-    executor: rust-executor
+    executor: default
     steps:
-      - checkout
-      - run: git merge --no-edit origin/master
+      - setup_docker_compose
       - run:
-          name: Setup Packages
-          command: |
-            apt-get update -y
-            apt-get install -y libclang-7-dev libv4l-dev
-      - run:
-          name: Setup Rust
-          command: |
-            rustup default << parameters.rust >>
-      - run:
-          name: Cargo test
-          command: |
-            cargo test
+          name: Test w/ rustc ver. << parameters.rust >>
+          environment:
+            RUST_VER: << parameters.rust >>
+          command: docker-compose run --rm libv4l-test
 
   cross_build:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,16 @@
 version: 2.1
 
 executors:
+  default:
+    docker:
+      - image: docker/compose
+    working_directory: /tmp/libv4l_sys
   rust-executor:
     docker:
       - image: rust:1.36.0-buster
     working_directory: /tmp/libv4l_sys
     environment:
       LIBCLANG_INCLUDE_PATH: /usr/include/clang/7/include
-
 
 constants:
   parameter-rust-version: &parameter-rust-version
@@ -61,35 +64,22 @@ jobs:
   cross_build:
     parameters:
       <<: *parameter-rust-version
-    executor: rust-executor
-    environment:
-      TARGET_ARCH: arm-unknown-linux-gnueabihf
-      LIBCLANG_INCLUDE_PATH: /usr/include/clang/7/include
-      PKG_CONFIG_PATH: /usr/lib/arm-linux-gnueabihf/pkgconfig
-      PKG_CONFIG_ALLOW_CROSS: 1
+    executor: default
     steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
       - checkout
+      - run:
+          name: Install git
+          command: |
+            apk add --update --no-cache git
       - run: git merge --no-edit origin/master
       - run:
-          name: Setup Packages
-          command: |
-            dpkg --add-architecture armhf
-            apt-get update -y
-            apt-get install -y libv4l-dev:armhf libclang-common-7-dev:armhf libclang-7-dev:armhf
-            apt-get install -y gcc-arm-linux-gnueabihf libclang-7-dev
-      - run:
-          name: Install Rust for ARM
-          command: |
-            rustup default << parameters.rust >>
-            rustup target add ${TARGET_ARCH}
-      - run:
-          name: Build crate
-          command: |
-            cargo build --target=${TARGET_ARCH}
-      - run:
-          name: Build example
-          command: |
-            cargo build --target=${TARGET_ARCH} --example v4l2grab
+          name: Cross build w/ rustc ver. << parameters.rust >>
+          environment:
+            RUST_VER: << parameters.rust >>
+            TARGET_ARCH: arm-unknown-linux-gnueabihf
+          command: docker-compose run --rm cross-build-rpi
 
 
 workflows:
@@ -117,4 +107,3 @@ workflows:
       - cross_build:
           name: cross_build_stable
           rust: stable
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
           name: Build w/ rustc ver. << parameters.rust >>
           environment:
             RUST_CHANNEL: << parameters.rust >>
-          command: docker-compose run --rm libv4l-build
+          command: |
+            docker-compose build libv4l-build
+            docker-compose run --rm libv4l-build
 
   test:
     parameters:
@@ -46,7 +48,9 @@ jobs:
           name: Test w/ rustc ver. << parameters.rust >>
           environment:
             RUST_CHANNEL: << parameters.rust >>
-          command: docker-compose run --rm libv4l-test
+          command: |
+            docker-compose build libv4l-test
+            docker-compose run --rm libv4l-test
 
   cross_build:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,9 @@ jobs:
           name: Cross build w/ rustc ver. << parameters.rust >>
           environment:
             RUST_CHANNEL: << parameters.rust >>
-          command: docker-compose run --rm libv4l-build-cross-armhf
-
+          command: |
+            docker-compose build libv4l-build-cross-armhf
+            docker-compose run --rm libv4l-build-cross-armhf
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,8 +82,7 @@ jobs:
           name: Cross build w/ rustc ver. << parameters.rust >>
           environment:
             RUST_VER: << parameters.rust >>
-            TARGET_ARCH: arm-unknown-linux-gnueabihf
-          command: docker-compose run --rm cross-build-rpi
+          command: docker-compose run --rm libv4l-build-cross-armhf
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,6 @@ executors:
     docker:
       - image: docker/compose
     working_directory: /tmp/libv4l_sys
-  rust-executor:
-    docker:
-      - image: rust:1.36.0-buster
-    working_directory: /tmp/libv4l_sys
-    environment:
-      LIBCLANG_INCLUDE_PATH: /usr/include/clang/7/include
 
 constants:
   parameter-rust-version: &parameter-rust-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,23 +33,14 @@ jobs:
   build:
     parameters:
       <<: *parameter-rust-version
-    executor: rust-executor
+    executor: default
     steps:
-      - checkout
-      - run: git merge --no-edit origin/master
+      - setup_docker_compose
       - run:
-          name: Setup Packages
-          command: |
-            apt-get update -y
-            apt-get install -y libclang-7-dev libv4l-dev
-      - run:
-          name: Setup Rust
-          command: |
-            rustup default << parameters.rust >>
-      - run:
-          name: Build crate
-          command: |
-            cargo build
+          name: Build w/ rustc ver. << parameters.rust >>
+          environment:
+            RUST_VER: << parameters.rust >>
+          command: docker-compose run --rm libv4l-build
 
   test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,17 @@ constants:
       type: string
       default: "1.36.0"
 
+commands:
+  setup_docker_compose:
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - checkout
+      - run:
+          name: Install git
+          command: apk add --update --no-cache git
+      - run: git merge --no-edit origin/master
+
 jobs:
   build:
     parameters:
@@ -66,14 +77,7 @@ jobs:
       <<: *parameter-rust-version
     executor: default
     steps:
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - checkout
-      - run:
-          name: Install git
-          command: |
-            apk add --update --no-cache git
-      - run: git merge --no-edit origin/master
+      - setup_docker_compose
       - run:
           name: Cross build w/ rustc ver. << parameters.rust >>
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - run:
           name: Build w/ rustc ver. << parameters.rust >>
           environment:
-            RUST_VER: << parameters.rust >>
+            RUST_CHANNEL: << parameters.rust >>
           command: docker-compose run --rm libv4l-build
 
   test:
@@ -45,7 +45,7 @@ jobs:
       - run:
           name: Test w/ rustc ver. << parameters.rust >>
           environment:
-            RUST_VER: << parameters.rust >>
+            RUST_CHANNEL: << parameters.rust >>
           command: docker-compose run --rm libv4l-test
 
   cross_build:
@@ -57,7 +57,7 @@ jobs:
       - run:
           name: Cross build w/ rustc ver. << parameters.rust >>
           environment:
-            RUST_VER: << parameters.rust >>
+            RUST_CHANNEL: << parameters.rust >>
           command: docker-compose run --rm libv4l-build-cross-armhf
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM rust:1.36.0-buster
+
+ENV LIBCLANG_INCLUDE_PATH '/usr/include/clang/7/include'
+ENV PKG_CONFIG_PATH '/usr/lib/arm-linux-gnueabihf/pkgconfig'
+ENV PKG_CONFIG_ALLOW_CROSS 1
+
+ARG RUST_VER
+RUN test ${RUST_VER}
+
+ARG TARGET_ARCH
+RUN test ${TARGET_ARCH}
+
+WORKDIR /tmp/libv4l_sys
+
+RUN dpkg --add-architecture armhf \
+    && apt-get update -y \
+    && apt-get install -y libv4l-dev:armhf libclang-common-7-dev:armhf libclang-7-dev:armhf \
+    && apt-get install -y gcc-arm-linux-gnueabihf libclang-7-dev
+
+RUN rustup install ${RUST_VER} \
+    && rustup target add --toolchain ${RUST_VER} ${TARGET_ARCH}
+
+COPY . /tmp/libv4l_sys

--- a/README.md
+++ b/README.md
@@ -7,37 +7,47 @@ Rust FFI wrapper to libv4l.
 
 ## Build
 
+### Build by docker-compose (RECOMMENDED)
+
+```sh
+(host)$ docker-compose build libv4l-build
+(host)$ docker-compose run --rm libv4l-build  # Just check if build succeeds
+
+# Manually invoke build command inside container
+(host)$ docker-compose run --rm libv4l-build bash
+(container)$ cargo build
+(container)$ file target/debug/liblibv4l_sys.rlib
+target/debug/liblibv4l_sys.rlib: current ar archive
+```
+
+### Native build (not RECOMMENDED)
+
+You need to install the dependencies by yourself:
+
+- libv4l (like `libv4l-dev`)
+- libclang-7 (like `libclang-7-dev`)
+
+And set the following environment variables:
+
+- LIBCLANG_INCLUDE_PATH (e.g. `export LIBCLANG_INCLUDE_PATH=/usr/include/clang/7/include`)
+
+Then execute:
+
 ```sh
 cargo build
 ```
 
-### Parameter
+## Cross Build
 
-You can specify some build parameters.
-
-- `LIBCLANG_INCLUDE_PATH`: Path to the system header directory
-
-    ```sh
-    LIBCLANG_INCLUDE_PATH=/usr/include/clang/7/include cargo build
-    ```
-
-### Cross build
-
-For cross compiling, some more configurations are required.
-
-#### Example (build for armhf)
+### Into `arm-unknown-linux-gnueabihf`
 
 ```sh
-libv4l-sys$ cat <<EOF > .cargo/config
-[target.arm-unknown-linux-gnueabihf]
-linker = "arm-rpi-linux-gnueabihf-gcc"
-rustflags = ["-C", "link-args=-Wl,-rpath-link,/usr/lib/arm-linux-gnueabihf"]
-EOF
-libv4l-sys$ export LIBCLANG_INCLUDE_PATH=/usr/include/clang/7/include
-libv4l-sys$ cargo build --target=arm-unknown-linux-gnueabihf
+(host)$ docker-compose build libv4l-build-cross-armhf
+(host)$ docker-compose run --rm libv4l-build-cross-armhf  # Just check if build succeeds
+
+# Manually invoke build command inside container
+(host)$ docker-compose run --rm libv4l-build-cross-armhf bash
+(container)$ cargo build --target=arm-unknown-linux-gnueabihf
+(container)$ file target/arm-unknown-linux-gnueabihf/debug/liblibv4l_sys.rlib
+target/arm-unknown-linux-gnueabihf/debug/liblibv4l_sys.rlib: current ar archive
 ```
-
-### Required package
-
-- libclang-7-dev
-- libv4l-dev

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Rust FFI wrapper to libv4l.
 
 ## Build
 
-### Build by docker-compose (RECOMMENDED)
+### Build by docker-compose
 
 ```sh
 (host)$ docker-compose build libv4l-build
@@ -20,7 +20,7 @@ Rust FFI wrapper to libv4l.
 target/debug/liblibv4l_sys.rlib: current ar archive
 ```
 
-### Native build (not RECOMMENDED)
+### Native build
 
 You need to install the dependencies by yourself:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,6 @@ services:
     command: |
       bash -xc "
       rustc --version
-      cargo build --target=arm-unknown-linux-gnueabihf || cargo build --target=arm-unknown-linux-gnueabihf  # FIXME: build fails in 1st build... https://app.circleci.com/pipelines/github/Idein/libv4l-sys/102/workflows/2e538f9c-c15a-4798-bc58-c9a7ac0c5faf/jobs/334
+      cargo build --target=arm-unknown-linux-gnueabihf
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     command: |
       bash -xc "
       rustc --version
+      rustup target add --toolchain ${RUST_CHANNEL} arm-unknown-linux-gnueabihf  # WHY???
       cargo build --target=arm-unknown-linux-gnueabihf || cargo build --target=arm-unknown-linux-gnueabihf  # FIXME: build fails in 1st build... https://app.circleci.com/pipelines/github/Idein/libv4l-sys/102/workflows/2e538f9c-c15a-4798-bc58-c9a7ac0c5faf/jobs/334
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_CHANNEL}-arm-unknown-linux-gnueabihf
+      rustup override set ${RUST_CHANNEL}
       cargo build --target=arm-unknown-linux-gnueabihf
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: dockerfiles/docker-libv4l-build/Dockerfile
       args:
-        - RUST_CHANNEL=${RUST_CHANNEL}
+        - RUST_CHANNEL=${RUST_CHANNEL:-stable}
     command: |
       bash -xc "
       rustc --version
@@ -21,7 +21,7 @@ services:
       context: .
       dockerfile: dockerfiles/docker-libv4l-build/Dockerfile
       args:
-        - RUST_CHANNEL=${RUST_CHANNEL}
+        - RUST_CHANNEL=${RUST_CHANNEL:-stable}
     command: |
       bash -xc "
       rustc --version
@@ -34,7 +34,7 @@ services:
       context: .
       dockerfile: dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
       args:
-        - RUST_CHANNEL=${RUST_CHANNEL}
+        - RUST_CHANNEL=${RUST_CHANNEL:-stable}
     command: |
       bash -xc "
       rustc --version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,33 +1,16 @@
 version: '3.4'
 
 services:
-  cross-rpi-rust: &cross-rust-env
-    image: rust:1.36.0-buster
-    container_name: cross-rpi-rust
-    environment:
-      TARGET_ARCH: 'arm-unknown-linux-gnueabihf'
-      LIBCLANG_INCLUDE_PATH: '/usr/include/clang/7/include'
-      PKG_CONFIG_PATH: '/usr/lib/arm-linux-gnueabihf/pkgconfig'
-      PKG_CONFIG_ALLOW_CROSS: 1
-    volumes:
-      - .:/tmp/libv4l_sys
-      - cargo-cache:/tmp/.cargo
-    working_dir: /tmp/libv4l_sys
-
-  # build project for RaspberryPi
-  cross-build:
-    << : *cross-rust-env
+  cross-build-rpi:
+    container_name: cross-build-rpi
+    build:
+      context: .
+      args:
+        - RUST_VER=${RUST_VER}
+        - TARGET_ARCH=${TARGET_ARCH}
     command: |
-      bash -c "
-      dpkg --add-architecture armhf
-      apt-get update -y
-      apt-get install -y libv4l-dev:armhf libclang-common-7-dev:armhf libclang-7-dev:armhf
-      apt-get install -y gcc-arm-linux-gnueabihf libclang-7-dev
-      rustup target add $${TARGET_ARCH}
-      cargo build --target=$${TARGET_ARCH}
-      cargo build --target=$${TARGET_ARCH} --example v4l2grab
+      bash -xc "
+      rustup override set ${RUST_VER}
+      cargo build --target=${TARGET_ARCH}
+      cargo build --target=${TARGET_ARCH} --examples
       "
-
-
-volumes:
-  cargo-cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     command: |
       bash -xc "
       rustc --version
-      rustup target add --toolchain ${RUST_CHANNEL} arm-unknown-linux-gnueabihf  # WHY???
+      #rustup target add --toolchain ${RUST_CHANNEL} arm-unknown-linux-gnueabihf  # WHY???
       cargo build --target=arm-unknown-linux-gnueabihf || cargo build --target=arm-unknown-linux-gnueabihf  # FIXME: build fails in 1st build... https://app.circleci.com/pipelines/github/Idein/libv4l-sys/102/workflows/2e538f9c-c15a-4798-bc58-c9a7ac0c5faf/jobs/334
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,19 @@ services:
       cargo build --examples
       "
 
+  libv4l-test:
+    container_name: libv4l-build
+    build:
+      context: .
+      dockerfile: dockerfiles/docker-libv4l-build/Dockerfile
+      args:
+        - RUST_VER=${RUST_VER}
+    command: |
+      bash -xc "
+      rustup override set ${RUST_VER}
+      cargo test --all
+      "
+
   libv4l-build-cross-armhf:
     container_name: libv4l-build-cross-armhf
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 version: '3.4'
 
 services:
-  cross-build-rpi:
-    container_name: cross-build-rpi
+  libv4l-build-cross-armhf:
+    container_name: libv4l-build-cross-armhf
     build:
       context: .
+      dockerfile: dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
       args:
         - RUST_VER=${RUST_VER}
-        - TARGET_ARCH=${TARGET_ARCH}
     command: |
       bash -xc "
       rustup override set ${RUST_VER}
-      cargo build --target=${TARGET_ARCH}
-      cargo build --target=${TARGET_ARCH} --examples
+      cargo build --target=arm-unknown-linux-gnueabihf
+      cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,6 @@ services:
     command: |
       bash -xc "
       rustc --version
-      #rustup target add --toolchain ${RUST_CHANNEL} arm-unknown-linux-gnueabihf  # WHY???
       cargo build --target=arm-unknown-linux-gnueabihf || cargo build --target=arm-unknown-linux-gnueabihf  # FIXME: build fails in 1st build... https://app.circleci.com/pipelines/github/Idein/libv4l-sys/102/workflows/2e538f9c-c15a-4798-bc58-c9a7ac0c5faf/jobs/334
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_CHANNEL}
+      rustup override set ${RUST_CHANNEL}-arm-unknown-linux-gnueabihf
       cargo build --target=arm-unknown-linux-gnueabihf
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 version: '3.4'
 
 services:
+  libv4l-build:
+    container_name: libv4l-build
+    build:
+      context: .
+      dockerfile: dockerfiles/docker-libv4l-build/Dockerfile
+      args:
+        - RUST_VER=${RUST_VER}
+    command: |
+      bash -xc "
+      rustup override set ${RUST_VER}
+      cargo build
+      cargo build --examples
+      "
+
   libv4l-build-cross-armhf:
     container_name: libv4l-build-cross-armhf
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_CHANNEL}
+      rustc --version
       cargo build
       cargo build --examples
       "
@@ -24,7 +24,7 @@ services:
         - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_CHANNEL}
+      rustc --version
       cargo test --all
       "
 
@@ -37,7 +37,7 @@ services:
         - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_CHANNEL}
+      rustc --version
       cargo build --target=arm-unknown-linux-gnueabihf || cargo build --target=arm-unknown-linux-gnueabihf  # FIXME: build fails in 1st build... https://app.circleci.com/pipelines/github/Idein/libv4l-sys/102/workflows/2e538f9c-c15a-4798-bc58-c9a7ac0c5faf/jobs/334
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,10 @@ services:
       context: .
       dockerfile: dockerfiles/docker-libv4l-build/Dockerfile
       args:
-        - RUST_VER=${RUST_VER}
+        - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_VER}
+      rustup override set ${RUST_CHANNEL}
       cargo build
       cargo build --examples
       "
@@ -21,10 +21,10 @@ services:
       context: .
       dockerfile: dockerfiles/docker-libv4l-build/Dockerfile
       args:
-        - RUST_VER=${RUST_VER}
+        - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_VER}
+      rustup override set ${RUST_CHANNEL}
       cargo test --all
       "
 
@@ -34,10 +34,10 @@ services:
       context: .
       dockerfile: dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
       args:
-        - RUST_VER=${RUST_VER}
+        - RUST_CHANNEL=${RUST_CHANNEL}
     command: |
       bash -xc "
-      rustup override set ${RUST_VER}
+      rustup override set ${RUST_CHANNEL}
       cargo build --target=arm-unknown-linux-gnueabihf
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,6 @@ services:
     command: |
       bash -xc "
       rustup override set ${RUST_CHANNEL}
-      cargo build --target=arm-unknown-linux-gnueabihf
+      cargo build --target=arm-unknown-linux-gnueabihf || cargo build --target=arm-unknown-linux-gnueabihf  # FIXME: build fails in 1st build... https://app.circleci.com/pipelines/github/Idein/libv4l-sys/102/workflows/2e538f9c-c15a-4798-bc58-c9a7ac0c5faf/jobs/334
       cargo build --target=arm-unknown-linux-gnueabihf --examples
       "

--- a/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.41.1-buster
+FROM rust:1.36.0-buster
 
 ENV LIBCLANG_INCLUDE_PATH '/usr/include/clang/7/include'
 ENV PKG_CONFIG_PATH '/usr/lib/arm-linux-gnueabihf/pkgconfig'

--- a/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.36.0-buster
+FROM rust:1.41.1-buster
 
 ENV LIBCLANG_INCLUDE_PATH '/usr/include/clang/7/include'
 ENV PKG_CONFIG_PATH '/usr/lib/arm-linux-gnueabihf/pkgconfig'

--- a/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
@@ -7,9 +7,6 @@ ENV PKG_CONFIG_ALLOW_CROSS 1
 ARG RUST_VER
 RUN test ${RUST_VER}
 
-ARG TARGET_ARCH
-RUN test ${TARGET_ARCH}
-
 WORKDIR /tmp/libv4l_sys
 
 RUN dpkg --add-architecture armhf \
@@ -18,6 +15,6 @@ RUN dpkg --add-architecture armhf \
     && apt-get install -y gcc-arm-linux-gnueabihf libclang-7-dev
 
 RUN rustup install ${RUST_VER} \
-    && rustup target add --toolchain ${RUST_VER} ${TARGET_ARCH}
+    && rustup target add --toolchain ${RUST_VER} arm-unknown-linux-gnueabihf
 
 COPY . /tmp/libv4l_sys

--- a/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
@@ -4,8 +4,8 @@ ENV LIBCLANG_INCLUDE_PATH '/usr/include/clang/7/include'
 ENV PKG_CONFIG_PATH '/usr/lib/arm-linux-gnueabihf/pkgconfig'
 ENV PKG_CONFIG_ALLOW_CROSS 1
 
-ARG RUST_VER
-RUN test ${RUST_VER}
+ARG RUST_CHANNEL
+RUN test ${RUST_CHANNEL}
 
 WORKDIR /tmp/libv4l_sys
 
@@ -14,6 +14,6 @@ RUN dpkg --add-architecture armhf \
     && apt-get install -y libv4l-dev:armhf libclang-common-7-dev:armhf libclang-7-dev:armhf \
     && apt-get install -y gcc-arm-linux-gnueabihf libclang-7-dev
 
-RUN rustup toolchain install ${RUST_VER}-arm-unknown-linux-gnueabihf
+RUN rustup toolchain install ${RUST_CHANNEL}-arm-unknown-linux-gnueabihf
 
 COPY . /tmp/libv4l_sys

--- a/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
@@ -18,3 +18,5 @@ RUN rustup toolchain install ${RUST_CHANNEL} \
     && rustup target add --toolchain ${RUST_CHANNEL} arm-unknown-linux-gnueabihf
 
 COPY . /tmp/libv4l_sys
+
+RUN rustup override set ${RUST_CHANNEL}

--- a/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
@@ -14,7 +14,6 @@ RUN dpkg --add-architecture armhf \
     && apt-get install -y libv4l-dev:armhf libclang-common-7-dev:armhf libclang-7-dev:armhf \
     && apt-get install -y gcc-arm-linux-gnueabihf libclang-7-dev
 
-RUN rustup install ${RUST_VER} \
-    && rustup target add --toolchain ${RUST_VER} arm-unknown-linux-gnueabihf
+RUN rustup toolchain install ${RUST_VER}-arm-unknown-linux-gnueabihf
 
 COPY . /tmp/libv4l_sys

--- a/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
+++ b/dockerfiles/docker-libv4l-build-cross-armhf/Dockerfile
@@ -14,6 +14,7 @@ RUN dpkg --add-architecture armhf \
     && apt-get install -y libv4l-dev:armhf libclang-common-7-dev:armhf libclang-7-dev:armhf \
     && apt-get install -y gcc-arm-linux-gnueabihf libclang-7-dev
 
-RUN rustup toolchain install ${RUST_CHANNEL}-arm-unknown-linux-gnueabihf
+RUN rustup toolchain install ${RUST_CHANNEL} \
+    && rustup target add --toolchain ${RUST_CHANNEL} arm-unknown-linux-gnueabihf
 
 COPY . /tmp/libv4l_sys

--- a/dockerfiles/docker-libv4l-build/Dockerfile
+++ b/dockerfiles/docker-libv4l-build/Dockerfile
@@ -13,3 +13,5 @@ RUN apt-get update -y \
 RUN rustup toolchain install ${RUST_CHANNEL}
 
 COPY . /tmp/libv4l_sys
+
+RUN rustup override set ${RUST_CHANNEL}

--- a/dockerfiles/docker-libv4l-build/Dockerfile
+++ b/dockerfiles/docker-libv4l-build/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /tmp/libv4l_sys
 RUN apt-get update -y \
     && apt-get install -y libv4l-dev libclang-7-dev
 
-RUN rustup install ${RUST_VER}
+RUN rustup toolchain install ${RUST_VER}
 
 COPY . /tmp/libv4l_sys

--- a/dockerfiles/docker-libv4l-build/Dockerfile
+++ b/dockerfiles/docker-libv4l-build/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.36.0-buster
+
+ARG RUST_VER
+RUN test ${RUST_VER}
+
+WORKDIR /tmp/libv4l_sys
+
+RUN apt-get update -y \
+    && apt-get install -y libv4l-dev libclang-7-dev
+
+RUN rustup install ${RUST_VER}
+
+COPY . /tmp/libv4l_sys

--- a/dockerfiles/docker-libv4l-build/Dockerfile
+++ b/dockerfiles/docker-libv4l-build/Dockerfile
@@ -1,5 +1,7 @@
 FROM rust:1.36.0-buster
 
+ENV LIBCLANG_INCLUDE_PATH '/usr/include/clang/7/include'
+
 ARG RUST_VER
 RUN test ${RUST_VER}
 

--- a/dockerfiles/docker-libv4l-build/Dockerfile
+++ b/dockerfiles/docker-libv4l-build/Dockerfile
@@ -2,14 +2,14 @@ FROM rust:1.36.0-buster
 
 ENV LIBCLANG_INCLUDE_PATH '/usr/include/clang/7/include'
 
-ARG RUST_VER
-RUN test ${RUST_VER}
+ARG RUST_CHANNEL
+RUN test ${RUST_CHANNEL}
 
 WORKDIR /tmp/libv4l_sys
 
 RUN apt-get update -y \
     && apt-get install -y libv4l-dev libclang-7-dev
 
-RUN rustup toolchain install ${RUST_VER}
+RUN rustup toolchain install ${RUST_CHANNEL}
 
 COPY . /tmp/libv4l_sys


### PR DESCRIPTION
## Motivation & Solutions

- Eliminate duplicate setup commands written both in `.circleci/config.yml` and `docker-compose.yml`
    - -> Write commands only in `docker-compose.yml`. `.circleci/config.yml` invokes `docker-compose` command.

- Stop using volume mount because [CircleCI does not support it with Docker Executor](https://circleci.com/docs/2.0/docker-compose/#using-docker-compose-with-docker-executor).
    - -> Uses `COPY` commands in `Dockerfile`.

## Other changes

- removes `rust-executor`, defined `default` executor instead.
- `cargo build --example v4l2grab` -> `cargo build --examples`